### PR TITLE
Expose oracledb instance

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -4,6 +4,8 @@ const fp = require('fastify-plugin')
 const oracledb = require('oracledb')
 
 function fastifyOracleDB (fastify, options, next) {
+  fastify.decorate("oracledb", oracledb);
+  
   const close = function (fastify, done) {
     fastify.oracle.close(done)
   }


### PR DESCRIPTION
Expose oracledb instance with a decorator so that we can configure it and use the constants such as `oracledb.OBJECT`