### PR TITLE
Added support for multiple oracle pools

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,6 +53,58 @@ takes precedence over the `pool` option.
 + `client`: an instance of an `oracledb` connection pool. This takes precedence
 over the `pool` and `poolAlias` options.
 
+A `name` option can be used in order to connect to multiple oracledb instances. 
+The first registered instance can be accessed via `fastify.oracle` or `fastify.oracle.<dbname>`. Note that once you register a *named* instance, you will *not* be able to register an unnamed instance.
+
+```js
+const fastify = require('fastify')()
+
+fastify
+  .register(require('fastify-oracle'), {
+    pool: {
+      user: 'foo',
+      password: 'bar',
+      connectString: 'oracle.example.com:1521/ora1'
+    },
+    name: 'ora1'
+  })
+  .register(require('fastify-oracle'), {
+    pool: {
+      user: 'foo',
+      password: 'bar',
+      connectString: 'oracle.example.com:1521/ora2'
+    },
+    name: 'ora2'
+  })
+
+fastify.get('/db_1_data', async function (req, reply) {
+  const conn = await this.oracle.ora1.getConnection()
+  const results = await conn.execute('select 1 as foo from dual')
+  await conn.close()
+  return results
+})
+
+fastify.get('/db_2_data', async function (req, reply) {
+  const conn = await this.oracle.ora2.getConnection()
+  const results = await conn.execute('select 1 as foo from dual')
+  await conn.close()
+  return results
+})
+```
+
+The `oracledb` instance is also available via `fastify.oracle.db` for accessing constants and other functionality:
+
+```js
+fastify.get('/db_data', async function (req, reply) {
+  const conn = await this.oracle.getConnection()
+  const results = await conn.execute('select 1 as foo from dual', { }, { outFormat: this.oracle.db.OBJECT })
+  await conn.close()
+  return results
+})
+```
+
+If needed `pool` instance can be accessed via `fastify.oracle[.dbname].pool`
+
 ## License
 
 [MIT License](http://jsumners.mit-license.org/)

--- a/plugin.js
+++ b/plugin.js
@@ -3,26 +3,61 @@
 const fp = require('fastify-plugin')
 const oracledb = require('oracledb')
 
-function fastifyOracleDB (fastify, options, next) {
-  const close = function (fastify, done) {
-    fastify.oracle.close(done)
+const close = function (fastify, done) {
+  Object.keys(fastify.oracle)
+    .forEach(key => {
+      if (fastify.oracle[key].pool) {
+        fastify.oracle[key].pool.close(done)
+      }
+    })
+
+  if (fastify.oracle.pool) {
+    fastify.oracle.pool.close(done)
+  }
+}
+
+function decorateFastifyInstance(pool, fastify, options, next) {
+  const oracle = {
+    getConnection: pool.getConnection.bind(pool),
+    pool
+  };
+
+  if (options.name) {
+    if (!fastify.oracle) {
+      fastify.decorate('oracle', Object.assign(oracle, { db: oracledb }))
+    }
+
+    if (fastify.oracle[options.name]) {
+      return next(new Error('Connection name has already been registered: ' + options.name))
+    }
+
+    fastify.oracle[options.name] = oracle
+  } else {
+    if (fastify.oracle) {
+      return next(new Error('fastify-oracle has already been registered'))
+    }
+    else {
+      fastify.decorate('oracle', Object.assign(oracle, { db: oracledb }))
+    }
   }
 
+  fastify.addHook('onClose', close)
+
+  return next()
+}
+
+function fastifyOracleDB(fastify, options, next) {
   if (options.client) {
     if (oracledb.Pool.prototype.isPrototypeOf(options.client) === false) {
       return next(Error('supplied client must be an instance of oracledb.pool'))
     }
-    fastify.decorate('oracle', options.client)
-    fastify.addHook('onClose', close)
-    return next()
+    return decorateFastifyInstance(options.client, fastify, options, next)
   }
 
   if (options.poolAlias) {
     const pool = oracledb.getPool(options.poolAlias)
-    if (!pool) return next('could not get default pool from oracledb instance')
-    fastify.decorate('oracle', pool)
-    fastify.addHook('onClose', close)
-    return next()
+    if (!pool) return next(Error('could not get default pool from oracledb instance'))
+    return decorateFastifyInstance(pool, fastify, options, next)
   }
 
   if (!options.pool) {
@@ -31,9 +66,7 @@ function fastifyOracleDB (fastify, options, next) {
 
   oracledb.createPool(options.pool, (err, pool) => {
     if (err) return next(err)
-    fastify.decorate('oracle', pool)
-    fastify.addHook('onClose', close)
-    next()
+    return decorateFastifyInstance(pool, fastify, options, next)
   })
 }
 


### PR DESCRIPTION
This PR adds support for multiple pool definitions.

*Changes*
- Options now support a `name` property for pool labeling (note that this is not `poolAlias`). Labeled clients can be accessed via `oracle.<dbname>.getConnection() `
- `oracledb` instance is exposed as `oracle.db` so that you can access constants and other options such as constants like `oracle.db.OBJECT`
- (*breaking*) `getConnection` is preserved but the pool instance is now accessed via `oracle.pool`

```js
fastify.register(require("fastify-oracle"), {
pool: {
  user: "oracle",
  password: "oracle",
  connectString: "oracle.local:1521/mydb"
},
name: 'mydb'
})

async function (request, reply) {
 // Or this.oracle.mydb.getConnection()
  const conn = await this.oracle.getConnection()
  try {
    const result = await conn.execute("SELECT 1 FROM DUAL",{ }, { outFormat:this.oracle.db.OBJECT })
    return result.rows
  } finally {
    await conn.close()
  }
}
```

```js
fastify.register(require("fastify-oracle"), {
pool: {
  user: "oracle",
  password: "oracle",
  connectString: "oracle.local:1521/mydb"
},
name: 'mydb'
}).register(require("fastify-oracle"), {
pool: {
  user: "oracle",
  password: "oracle",
  connectString: "oracle.local:1521/mydb"
},
name: 'otherdb'
})

async function (request, reply) {
  const myConn = await this.oracle.mydb.getConnection()
  const otherConn= await this.oracle.otherdb.getConnection()

  try {
    const myResult = await myConn.execute("SELECT 1 FROM DUAL",{ },{ outFormat: this.oracle.db.OBJECT })
    const otherResult = await otherConn.execute("SELECT 1 FROM DUAL",{ },{ outFormat: this.oracle.db.OBJECT})

    return {myResult, otherResult}
  } finally {
    await myConn .close()
    await otherConn.close()
  }
}
```

