### PR TITLE
Add direct query support, drop node 6, refactor tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ sudo: required
 dist: xenial
 
 node_js:
-  - "11"
   - "10"
   - "8"
-  - "6"
   
 script:
   - npm run test

--- a/README.md
+++ b/README.md
@@ -41,16 +41,14 @@ fastify.register(require('fastify-oracle'), {
 })
 
 fastify.get('/db_data', async function (req, reply) {
-  let conn
+  let connection
   try {
-    conn = await this.oracle.getConnection()
-    const result = await conn.execute('select 1 as foo from dual')  
-    return result.rows
+    connection = await this.oracle.getConnection()
+    const { rows } = await connection.execute('SELECT 1 AS FOO FROM DUAL')
+    return rows
   } finally {
-    if (conn) {
-      conn.close().catch((err) => {})
-    }
-  }  
+    if (connection) await connection.close()
+  }
 })
 
 fastify.listen(3000, (err) => {
@@ -83,7 +81,7 @@ fastify.register(require('fastify-oracle'), {
 
 fastify.post('/user/:username', (req, reply) => {
   // will return a promise, fastify will send the result automatically
-  return fastify.oracle.query('SELECT * FROM USERS')
+  return fastify.oracle.query('SELECT * FROM USERS WHERE NAME = :name', { name: 'james' })
 })
 
 /* or with a callback

--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
   },
   "homepage": "https://github.com/cemremengu/fastify-oracle#readme",
   "devDependencies": {
-    "fastify": "^1.13.3",
+    "fastify": "2.0.0-rc.5",
     "pre-commit": "^1.2.2",
     "snazzy": "^8.0.0",
     "standard": "^12.0.1",
-    "tap": "^12.1.1"
+    "tap": "^12.5.1"
   },
   "dependencies": {
-    "fastify-plugin": "^1.4.0",
-    "oracledb": "^3.0.1"
+    "fastify-plugin": "^1.5.0",
+    "oracledb": "^3.1.1"
   }
 }

--- a/test/opts.test.js
+++ b/test/opts.test.js
@@ -5,112 +5,111 @@ const plugin = require('../plugin')
 const Fastify = require('fastify')
 const oracledb = require('oracledb')
 
-test('client must be instance of oracledb.pool', (t) => {
-  t.plan(1)
-
+test('client must be instance of oracledb.pool', async (t) => {
   const fastify = Fastify()
-
   fastify.register(plugin, { client: 'hello world' })
 
-  fastify.ready(err => {
+  try {
+    await fastify.ready()
+  } catch (err) {
     t.is(err.message, 'fastify-oracle: supplied client must be an instance of oracledb.pool')
-    fastify.close()
-  })
+    await fastify.close()
+  }
 })
 
-test('duplicate connection names should throw', (t) => {
-  t.plan(1)
-
+test('duplicate connection names should throw', async (t) => {
   const fastify = Fastify()
-
   fastify
     .register(plugin, { pool: {}, name: 'testdb' })
     .register(plugin, { pool: {}, name: 'testdb' })
 
-  fastify.ready(err => {
+  try {
+    await fastify.ready()
+  } catch (err) {
     t.is(err.message, 'fastify-oracle: connection name "testdb" has already been registered')
-    fastify.close()
-  })
+    await fastify.close()
+  }
 })
 
-test('duplicate plugin registration should throw', (t) => {
-  t.plan(1)
-
+test('duplicate plugin registration should throw', async (t) => {
   const fastify = Fastify()
 
   fastify
     .register(plugin, { pool: {} })
     .register(plugin, { pool: {} })
 
-  fastify.ready(err => {
+  try {
+    await fastify.ready()
+  } catch (err) {
     t.is(err.message, 'fastify-oracle has already been registered')
-    fastify.close()
-  })
+    await fastify.close()
+  }
 })
 
-test('should throw if no pool option is provided', (t) => {
-  t.plan(1)
-
+test('should throw if no pool option is provided', async (t) => {
   const fastify = Fastify()
 
   fastify.register(plugin, {})
-  fastify.ready(err => {
+
+  try {
+    await fastify.ready()
+  } catch (err) {
     t.is(err.message, 'fastify-oracle: must supply options.pool oracledb pool options')
-    fastify.close()
-  })
+    await fastify.close()
+  }
 })
 
-test('should throw if could not get pool alias', (t) => {
-  t.plan(1)
-
+test('should throw if could not get pool alias', async (t) => {
   const fastify = Fastify()
 
   fastify.register(plugin, { poolAlias: 'test' })
 
-  fastify.ready(err => {
+  try {
+    await fastify.ready()
+  } catch (err) {
     t.match(err.message, 'fastify-oracle: could not get pool alias')
-    fastify.close()
-  })
+    await fastify.close()
+  }
 })
 
-test('should throw if pool cannot be created', (t) => {
-  t.plan(1)
-
+test('should throw if pool cannot be created', async (t) => {
   const fastify = Fastify()
 
   fastify.register(plugin, { pool: { poolMin: -5 } })
 
-  fastify.ready(err => {
+  try {
+    await fastify.ready()
+  } catch (err) {
     t.match(err.message, 'fastify-oracle: failed to create pool')
-    fastify.close()
-  })
+    await fastify.close()
+  }
 })
 
-test('sets OBJECT as default outFormat', (t) => {
-  t.plan(3)
-
+test('sets OBJECT as default outFormat', async (t) => {
+  const fastify = Fastify()
   oracledb.outFormat = oracledb.ARRAY
 
-  const fastify = Fastify()
   fastify.register(plugin, { pool: {}, outFormat: 'OBJECT' })
 
-  fastify.ready(err => {
-    t.error(err)
+  try {
+    await fastify.ready()
     t.ok(fastify.oracle.pool)
     t.is(fastify.oracle.db.outFormat, fastify.oracle.db.OBJECT)
     oracledb.outFormat = oracledb.ARRAY
-  })
+  } catch (err) {
+    t.error(err)
+  }
 })
 
-test('sets fetchAsString values', (t) => {
-  t.plan(3)
-
+test('sets fetchAsString values', async (t) => {
   const fastify = Fastify()
   fastify.register(plugin, { pool: {}, fetchAsString: ['NUMBER'] })
 
-  fastify.ready(err => {
-    t.error(err)
+  try {
+    await fastify.ready()
     t.ok(fastify.oracle.pool)
     t.deepEquals(fastify.oracle.db.fetchAsString, [fastify.oracle.db.NUMBER])
-  })
+  } catch (err) {
+    t.error(err)
+  }
 })

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -24,6 +24,10 @@ test('creates pool from config', async (t) => {
     t.is(result.rows.length, 1)
     t.is(result.rows[0].FOO, 1)
 
+    // Note that we don't explicity close the connection here.
+    // This tests the drainTime option since if a drainTime is not given,
+    // then any open connections should be released with connection.close() before fastify.close() is called, 
+    // otherwise the underlying pool close will fail and the pool will remain open.
     await fastify.close()
     t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
   } catch (err) {

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -11,120 +11,122 @@ const poolOptions = {
   connectString: 'localhost/xe'
 }
 
-test('creates pool from config', (t) => {
-  t.plan(9)
-
+test('creates pool from config', async (t) => {
   const fastify = Fastify()
-  fastify.register(plugin, { pool: poolOptions })
 
-  fastify.ready(err => {
-    t.error(err)
+  try {
+    fastify.register(plugin, { pool: poolOptions, drainTime: 0 })
+    await fastify.ready()
+
     t.ok(fastify.oracle.pool)
+    const conn = await fastify.oracle.getConnection()
+    const result = await conn.execute('SELECT 1 AS FOO FROM DUAL', {}, { outFormat: fastify.oracle.db.OBJECT })
+    t.is(result.rows.length, 1)
+    t.is(result.rows[0].FOO, 1)
 
-    fastify.oracle.getConnection((err, conn) => {
-      t.error(err)
-      conn.execute('SELECT 1 AS FOO FROM DUAL', {}, { outFormat: fastify.oracle.db.OBJECT }, (err, result) => {
-        t.error(err)
-        t.is(result.rows.length, 1)
-        t.is(result.rows[0].FOO, 1)
-        conn.close(err => {
-          t.error(err)
-
-          fastify.close(err => {
-            t.error(err)
-            t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
-          })
-        })
-      })
-    })
-  })
+    await fastify.close()
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+  } catch (err) {
+    t.error(err)
+  }
 })
 
-test('creates named pool from config', (t) => {
-  t.plan(11)
-
+test('creates named pool from config', async (t) => {
   const fastify = Fastify()
-  fastify.register(plugin, { pool: poolOptions, name: 'testdb' })
 
-  fastify.ready(err => {
-    t.error(err)
+  try {
+    fastify.register(plugin, { pool: poolOptions, name: 'testdb' })
+    await fastify.ready()
+
     t.ok(fastify.oracle.pool)
     t.ok(fastify.oracle.testdb.pool)
+    const conn = await fastify.oracle.getConnection()
+    const result = await conn.execute('SELECT 1 AS FOO FROM DUAL', {}, { outFormat: fastify.oracle.db.OBJECT })
+    t.is(result.rows.length, 1)
+    t.is(result.rows[0].FOO, 1)
 
-    fastify.oracle.testdb.getConnection((err, conn) => {
-      t.error(err)
+    await conn.close()
+    await fastify.close()
 
-      conn.execute('SELECT 1 AS FOO FROM DUAL', {}, { outFormat: fastify.oracle.db.OBJECT }, (err, result) => {
-        t.error(err)
-        t.is(result.rows.length, 1)
-        t.is(result.rows[0].FOO, 1)
-        conn.close(err => {
-          t.error(err)
-
-          fastify.close(err => {
-            t.error(err)
-            t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
-            t.is(fastify.oracle.testdb.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
-          })
-        })
-      })
-    })
-  })
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+    t.is(fastify.oracle.testdb.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+  } catch (err) {
+    t.error(err)
+  }
 })
 
-test('accepts singleton client', (t) => {
-  t.plan(7)
-  oracledb.createPool(poolOptions, (err, pool) => {
-    t.error(err)
+test('accepts singleton client', async (t) => {
+  const fastify = Fastify()
 
-    const fastify = Fastify()
+  try {
+    const pool = await oracledb.createPool(poolOptions)
     fastify.register(plugin, { client: pool })
+    await fastify.ready()
 
-    fastify.ready(err => {
-      t.error(err)
-      t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_OPEN)
-      t.is(fastify.oracle.db, oracledb)
-      t.is(fastify.oracle.pool, pool)
-      fastify.close(err => {
-        t.error(err)
-        t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
-      })
-    })
-  })
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_OPEN)
+    t.is(fastify.oracle.db, oracledb)
+    t.is(fastify.oracle.pool, pool)
+
+    await fastify.close()
+
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+  } catch (err) {
+    t.error(err)
+  }
 })
 
-test('retrieves a cached pool', (t) => {
-  t.plan(7)
-
+test('retrieves a cached pool', async (t) => {
+  const fastify = Fastify()
   const opts = Object.assign({}, poolOptions)
-  oracledb.createPool(Object.assign(opts, { poolAlias: 'foo' }), (err, pool) => {
-    t.error(err)
 
-    const fastify = Fastify()
+  try {
+    const pool = await oracledb.createPool(Object.assign(opts, { poolAlias: 'foo' }))
     fastify.register(plugin, { poolAlias: 'foo' })
 
-    fastify.ready(err => {
-      t.error(err)
-      t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_OPEN)
-      t.is(fastify.oracle.db, oracledb)
-      t.is(fastify.oracle.pool, pool)
-      fastify.close(err => {
-        t.error(err)
-        t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
-      })
+    await fastify.ready()
+
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_OPEN)
+    t.is(fastify.oracle.db, oracledb)
+    t.is(fastify.oracle.pool, pool)
+
+    await fastify.close()
+
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+  } catch (err) {
+    t.error(err)
+  }
+})
+
+test('transact with async/await', async (t) => {
+  const fastify = Fastify()
+
+  try {
+    fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
+    await fastify.ready()
+
+    const { rows } = await fastify.oracle.transact(async conn => {
+      const res = await conn.execute('SELECT * FROM DUAL')
+      t.strictDeepEqual(res.rows, [ { DUMMY: 'X' } ])
+
+      return conn.execute('SELECT * FROM DUAL')
     })
-  })
+
+    t.strictDeepEqual(rows, [ { DUMMY: 'X' } ])
+    await fastify.close()
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+  } catch (err) {
+    t.error(err)
+  }
 })
 
 test('transact with promise', (t) => {
-  t.plan(6)
+  t.plan(5)
 
   const fastify = Fastify()
   fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
 
   fastify.ready(err => {
     t.error(err)
-    t.ok(fastify.oracle.pool)
 
     fastify.oracle.transact(conn => {
       return conn.execute('SELECT * FROM DUAL')
@@ -141,14 +143,13 @@ test('transact with promise', (t) => {
 })
 
 test('transact with callback', (t) => {
-  t.plan(6)
+  t.plan(5)
 
   const fastify = Fastify()
   fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
 
   fastify.ready(err => {
     t.error(err)
-    t.ok(fastify.oracle.pool)
 
     fastify.oracle.transact(conn => {
       return conn.execute('SELECT * FROM DUAL')
@@ -165,14 +166,13 @@ test('transact with callback', (t) => {
 })
 
 test('transact with commit callback', (t) => {
-  t.plan(6)
+  t.plan(5)
 
   const fastify = Fastify()
   fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
 
   fastify.ready(err => {
     t.error(err)
-    t.ok(fastify.oracle.pool)
 
     fastify.oracle.transact((conn, commit) => {
       conn.execute('SELECT * FROM DUAL', function (err, result) {
@@ -190,14 +190,13 @@ test('transact with commit callback', (t) => {
 })
 
 test('transact with promise (error)', (t) => {
-  t.plan(5)
+  t.plan(4)
 
   const fastify = Fastify()
   fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
 
   fastify.ready(err => {
     t.error(err)
-    t.ok(fastify.oracle.pool)
 
     fastify.oracle.transact(conn => {
       return conn.execute('SELECT * FROM ??')
@@ -213,14 +212,13 @@ test('transact with promise (error)', (t) => {
 })
 
 test('transact with callback (error)', (t) => {
-  t.plan(6)
+  t.plan(5)
 
   const fastify = Fastify()
   fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
 
   fastify.ready(err => {
     t.error(err)
-    t.ok(fastify.oracle.pool)
 
     fastify.oracle.transact(conn => {
       return conn.execute('SELECT * FROM ??')
@@ -237,14 +235,13 @@ test('transact with callback (error)', (t) => {
 })
 
 test('transact with commit callback (error)', (t) => {
-  t.plan(6)
+  t.plan(5)
 
   const fastify = Fastify()
   fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
 
   fastify.ready(err => {
     t.error(err)
-    t.ok(fastify.oracle.pool)
 
     fastify.oracle.transact((conn, commit) => {
       conn.execute('SELECT * FROM ??', function (err, result) {
@@ -261,62 +258,30 @@ test('transact with commit callback (error)', (t) => {
   })
 })
 
-test('transact with callback + invalid connection pool', (t) => {
-  t.plan(6)
-
+test('transact should fail if connection pool is invalid', async (t) => {
   const fastify = Fastify()
-  fastify.register(plugin, { pool: {}, outFormat: 'object' })
 
-  fastify.ready(err => {
-    t.error(err)
-    t.ok(fastify.oracle.pool)
-
-    fastify.oracle.transact(conn => {
+  try {
+    fastify.register(plugin, { pool: {}, outFormat: 'OBJECT' })
+    await fastify.ready()
+    await fastify.oracle.transact(conn => {
       return conn.execute('SELECT * FROM DUAL')
-    },
-    function (err, res) {
-      t.is(res, undefined)
-      t.is(err.message, 'ORA-24415: Missing or null username.')
-      fastify.close(err => {
-        t.error(err)
-        t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
-      })
     })
-  })
-})
-
-test('transact with promise + invalid connection pool', (t) => {
-  t.plan(5)
-
-  const fastify = Fastify()
-  fastify.register(plugin, { pool: {}, outFormat: 'OBJECT' })
-
-  fastify.ready(err => {
-    t.error(err)
-    t.ok(fastify.oracle.pool)
-
-    fastify.oracle.transact(conn => {
-      return conn.execute('SELECT * FROM DUAL')
-    }).catch((err) => {
-      t.is(err.message, 'ORA-24415: Missing or null username.')
-
-      fastify.close(err => {
-        t.error(err)
-        t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
-      })
-    })
-  })
+  } catch (err) {
+    t.is(err.message, 'ORA-24415: Missing or null username.')
+    await fastify.close()
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+  }
 })
 
 test('transact commit should error if connection drops', (t) => {
-  t.plan(6)
+  t.plan(5)
 
   const fastify = Fastify()
   fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
 
   fastify.ready(err => {
     t.error(err)
-    t.ok(fastify.oracle.pool)
 
     fastify.oracle.transact((conn, commit) => {
       conn.execute('SELECT * FROM DUAL', function (err, result) {
@@ -333,4 +298,191 @@ test('transact commit should error if connection drops', (t) => {
       })
     })
   })
+})
+
+test('query with async/await', async (t) => {
+  const fastify = Fastify()
+
+  try {
+    fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
+    await fastify.ready()
+
+    const { rows } = await fastify.oracle.query('SELECT * FROM DUAL')
+
+    t.strictDeepEqual(rows, [ { DUMMY: 'X' } ])
+    await fastify.close()
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+  } catch (err) {
+    t.error(err)
+  }
+})
+
+test('query with async/await + values', async (t) => {
+  const fastify = Fastify()
+
+  try {
+    fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
+    await fastify.ready()
+
+    const { rows } = await fastify.oracle.query('SELECT * FROM DUAL WHERE 1 = :v', [1])
+
+    t.strictDeepEqual(rows, [ { DUMMY: 'X' } ])
+    await fastify.close()
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+  } catch (err) {
+    t.error(err)
+  }
+})
+
+test('query with async/await + values + options', async (t) => {
+  const fastify = Fastify()
+
+  try {
+    fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
+    await fastify.ready()
+
+    const { rows } = await fastify.oracle.query('SELECT * FROM DUAL WHERE 1 = :v', [1], { outFormat: oracledb.ARRAY })
+
+    t.strictDeepEqual(rows, [ ['X'] ])
+    await fastify.close()
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+  } catch (err) {
+    t.error(err)
+  }
+})
+
+test('query with promise', (t) => {
+  t.plan(5)
+
+  const fastify = Fastify()
+  fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.oracle.query('SELECT * FROM DUAL').then((res, err) => {
+      t.error(err)
+      t.strictDeepEqual(res.rows, [ { DUMMY: 'X' } ])
+
+      fastify.close(err => {
+        t.error(err)
+        t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+      })
+    })
+  })
+})
+
+test('query with callback', (t) => {
+  t.plan(5)
+
+  const fastify = Fastify()
+  fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.oracle.query('SELECT * FROM DUAL', function (err, res) {
+      t.error(err)
+      t.strictDeepEqual(res.rows, [ { DUMMY: 'X' } ])
+      fastify.close(err => {
+        t.error(err)
+        t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+      })
+    })
+  })
+})
+
+test('query with callback + values', (t) => {
+  t.plan(5)
+
+  const fastify = Fastify()
+  fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.oracle.query('SELECT * FROM DUAL WHERE 1 = :v', [1], function (err, res) {
+      t.error(err)
+      t.strictDeepEqual(res.rows, [ { DUMMY: 'X' } ])
+      fastify.close(err => {
+        t.error(err)
+        t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+      })
+    })
+  })
+})
+
+test('query with callback + values + options', (t) => {
+  t.plan(5)
+
+  const fastify = Fastify()
+  fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.oracle.query('SELECT * FROM DUAL WHERE 1 = :v', [1], { outFormat: oracledb.ARRAY }, function (err, res) {
+      t.error(err)
+      t.strictDeepEqual(res.rows, [ ['X'] ])
+      fastify.close(err => {
+        t.error(err)
+        t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+      })
+    })
+  })
+})
+
+test('query with promise (error)', (t) => {
+  t.plan(4)
+
+  const fastify = Fastify()
+  fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.oracle.query('SELECT * FROM ??').catch((err) => {
+      t.is(err.message, 'ORA-00911: invalid character')
+
+      fastify.close(err => {
+        t.error(err)
+        t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+      })
+    })
+  })
+})
+
+test('query with callback (error)', (t) => {
+  t.plan(5)
+
+  const fastify = Fastify()
+  fastify.register(plugin, { pool: poolOptions, outFormat: 'OBJECT' })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.oracle.query('SELECT * FROM ??',
+      function (err, res) {
+        t.is(res, undefined)
+        t.is(err.message, 'ORA-00911: invalid character')
+        fastify.close(err => {
+          t.error(err)
+          t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+        })
+      })
+  })
+})
+
+test('query should fail if connection pool is invalid', async (t) => {
+  const fastify = Fastify()
+
+  try {
+    fastify.register(plugin, { pool: {}, outFormat: 'OBJECT' })
+    await fastify.ready()
+    await fastify.oracle.query('SELECT * FROM DUAL')
+  } catch (err) {
+    t.is(err.message, 'ORA-24415: Missing or null username.')
+    await fastify.close()
+    t.is(fastify.oracle.pool.status, fastify.oracle.db.POOL_STATUS_CLOSED)
+  }
 })


### PR DESCRIPTION
This PR:

- Adds direct query support (with `query` helper)
- Drops node 6 support (use at your own risk)
- Adds `drainTime` option
